### PR TITLE
Fixed issue where the join button would not be pressed

### DIFF
--- a/zoomrec.py
+++ b/zoomrec.py
@@ -231,6 +231,7 @@ def join_meeting(meet_id):
     pyautogui.press('tab')
     pyautogui.press('space')
     pyautogui.press('tab')
+    pyautogui.press('tab')
     pyautogui.press('space')
 
     time.sleep(2)


### PR DESCRIPTION
## Problem

Based on issue #10 

The script would not input the passcode when joining the meeting. This was due to a new change to the zoom client that added a terms and conditions text in the join-meeting screen. This would prevent the script from triggering the "join" button since the text would be selected instead of the button.

![image](https://user-images.githubusercontent.com/8559906/130679544-526f6ba0-b4db-47c4-a619-3535d98ff200.png)


## Solution

Add an extra tab in order to get to the button.