### PR TITLE
Fix pulseaudio not starting on container reboot

### DIFF
--- a/res/entrypoint.sh
+++ b/res/entrypoint.sh
@@ -31,6 +31,9 @@ echo -e "\nConnect to $VNC_IP:$VNC_PORT"
 # Start xfce4
 "$HOME"/xfce.sh &> "$START_DIR"/xfce.log
 
+# Cleanup to ensure pulseaudio is stateless
+rm -rf /var/run/pulse /var/lib/pulse /home/zoomrec/.config/pulse
+
 # Start audio
 pulseaudio -D --exit-idle-time=-1 --log-level=error
 


### PR DESCRIPTION
The pulseaudio daemon prevents the container from starting upon a reboot, showing logs similar to #8. Pulseaudio generates configuration files which need to be removed in order for it to cleanly start, as suggested in [this Stackoverflow answer](https://superuser.com/a/1545361).

I've added the necessary cleanup to the entrypoint. In my testing this allowed for the container to be restarted succesfully.

This is my first pullrequest, so let me know if I should have done things differently. Thanks :)