### PR TITLE
we don't need '--security-opt seccomp:unconfined', by adding '--no-sandbox' when opening zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ docker run -d --restart unless-stopped \
   -v $(pwd)/example/audio:/home/zoomrec/audio \
   -v $(pwd)/example/meetings.csv:/home/zoomrec/meetings.csv:ro \
   -p 5901:5901 \
-  --security-opt seccomp:unconfined \
 kastldratza/zoomrec:latest
 ```
 
@@ -147,7 +146,6 @@ docker run -d --restart unless-stopped \
   -v $(pwd)/example/audio:/home/zoomrec/audio \
   -v $(pwd)/example/meetings.csv:/home/zoomrec/meetings.csv:ro \
   -p 5901:5901 \
-  --security-opt seccomp:unconfined \
 kastldratza/zoomrec:latest
 ```
 #### Set Telegram details
@@ -159,7 +157,6 @@ docker run -d --restart unless-stopped \
   -v $(pwd)/example/audio:/home/zoomrec/audio \
   -v $(pwd)/example/meetings.csv:/home/zoomrec/meetings.csv:ro \
   -p 5901:5901 \
-  --security-opt seccomp:unconfined \
 kastldratza/zoomrec:latest
 ```
 #### Set Zoom display name 
@@ -170,7 +167,6 @@ docker run -d --restart unless-stopped \
   -v $(pwd)/example/audio:/home/zoomrec/audio \
   -v $(pwd)/example/meetings.csv:/home/zoomrec/meetings.csv:ro \
   -p 5901:5901 \
-  --security-opt seccomp:unconfined \
 kastldratza/zoomrec:latest
 ```
 ### Windows / _cmd_
@@ -181,7 +177,6 @@ docker run -d --restart unless-stopped \
   -v %cd%\example\audio:/home/zoomrec/audio \
   -v %cd%\example\meetings.csv:/home/zoomrec/meetings.csv:ro \
   -p 5901:5901 \
-  --security-opt seccomp:unconfined \
 kastldratza/zoomrec:latest
 ```
 
@@ -193,7 +188,6 @@ docker run -d --restart unless-stopped `
   -v ${PWD}/example/audio:/home/zoomrec/audio `
   -v ${PWD}/example/meetings.csv:/home/zoomrec/meetings.csv:ro `
   -p 5901:5901 `
-  --security-opt seccomp:unconfined `
 kastldratza/zoomrec:latest
 ```
 
@@ -205,7 +199,6 @@ docker run -d --restart unless-stopped \
   -v $(pwd)/example/audio:/home/zoomrec/audio \
   -v $(pwd)/example/meetings.csv:/home/zoomrec/meetings.csv:ro \
   -p 5901:5901 \
-  --security-opt seccomp:unconfined \
 kastldratza/zoomrec:latest
 ```
 
@@ -222,13 +215,13 @@ docker build -t kastldratza/zoomrec-custom:latest .
 
 # Run image without mounting meetings.csv and audio directory
 # Linux
-docker run -d --restart unless-stopped -v $(pwd)/recordings:/home/zoomrec/recordings -p 5901:5901 --security-opt seccomp:unconfined kastldratza/zoomrec-custom:latest
+docker run -d --restart unless-stopped -v $(pwd)/recordings:/home/zoomrec/recordings -p 5901:5901 kastldratza/zoomrec-custom:latest
 
 # Windows / PowerShell
-docker run -d --restart unless-stopped -v ${PWD}/recordings:/home/zoomrec/recordings -p 5901:5901 --security-opt seccomp:unconfined kastldratza/zoomrec-custom:latest
+docker run -d --restart unless-stopped -v ${PWD}/recordings:/home/zoomrec/recordings -p 5901:5901 kastldratza/zoomrec-custom:latest
 
 # Windows / cmd
-docker run -d --restart unless-stopped -v %cd%\recordings:/home/zoomrec/recordings -p 5901:5901 --security-opt seccomp:unconfined kastldratza/zoomrec-custom:latest
+docker run -d --restart unless-stopped -v %cd%\recordings:/home/zoomrec/recordings -p 5901:5901 kastldratza/zoomrec-custom:latest
 ```
 
 ---

--- a/zoomrec.py
+++ b/zoomrec.py
@@ -446,12 +446,12 @@ def join(meet_id, meet_pw, duration, description):
 
     if not join_by_url:
         # Start Zoom
-        zoom = subprocess.Popen("zoom", stdout=subprocess.PIPE,
+        zoom = subprocess.Popen(("zoom", "--no-sandbox"), stdout=subprocess.PIPE,
                                 shell=True, preexec_fn=os.setsid)
         img_name = 'join_meeting.png'
     else:
         logging.info("Starting zoom with url")
-        zoom = subprocess.Popen(f'zoom --url="{meet_id}"', stdout=subprocess.PIPE,
+        zoom = subprocess.Popen(("zoom", "--no-sandbox", f'--url="{meet_id}"'), stdout=subprocess.PIPE,
                                 shell=True, preexec_fn=os.setsid)
         img_name = 'join.png'
     


### PR DESCRIPTION
We might want to run this project on aws ecs, but `--security-opt seccomp:unconfined` doesn't supported on it.
It can be replaced by adding `--no-sandbox` option when opening zoom.

https://github.com/aws/containers-roadmap/issues/356